### PR TITLE
Improve Minestom fork

### DIFF
--- a/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
+++ b/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
@@ -52,7 +52,12 @@ class MinestomCommandManager(plugin: MinestomPlugin, debugMode: Boolean = false)
 
         val (subcommand, parameters) = result
         subcommand.method.isAccessible = true
-        
+
+        // Validate we're the correct sender
+        val senderType = subcommand.method.parameterTypes[0]
+        if (!senderType.isAssignableFrom(sender::class.java))
+            return false
+
         subcommand.method.invoke(null, sender, *parameters.toTypedArray())
 
         return true

--- a/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
+++ b/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
@@ -15,6 +15,7 @@ import net.minestom.server.command.builder.arguments.ArgumentType
 import net.minestom.server.command.builder.condition.CommandCondition
 import net.minestom.server.entity.Player
 import net.minestom.server.permission.Permission
+import java.lang.reflect.Modifier
 
 class MinestomCommandManager(plugin: MinestomPlugin, debugMode: Boolean = false) : CommandManager<MinestomPlugin>(Plugin(plugin), debugMode) {
     init {
@@ -50,6 +51,8 @@ class MinestomCommandManager(plugin: MinestomPlugin, debugMode: Boolean = false)
         }
 
         val (subcommand, parameters) = result
+        subcommand.method.isAccessible = true
+        
         subcommand.method.invoke(null, sender, *parameters.toTypedArray())
 
         return true

--- a/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
+++ b/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
@@ -58,7 +58,11 @@ class MinestomCommandManager(plugin: MinestomPlugin, debugMode: Boolean = false)
         if (!senderType.isAssignableFrom(sender::class.java))
             return false
 
-        subcommand.method.invoke(null, sender, *parameters.toTypedArray())
+        val instance =
+            if (Modifier.isStatic(subcommand.method.modifiers)) null
+            else subcommand.method.declaringClass.getDeclaredField("INSTANCE")[null]
+
+        subcommand.method.invoke(instance, sender, *parameters.toTypedArray())
 
         return true
     }


### PR DESCRIPTION
Allow private functions for commands, validate the sender class, and invoke with the correct instance