### PR TITLE
Fix tab completions for both Minestom and Spigot

### DIFF
--- a/common/src/main/kotlin/me/honkling/commando/common/TabCompleter.kt
+++ b/common/src/main/kotlin/me/honkling/commando/common/TabCompleter.kt
@@ -37,6 +37,11 @@ fun tabComplete(manager: CommandManager<*>, sender: ICommandSender<*>, node: Com
 
     manager.debugLog("Arguments list post prune: $mutableArgs")
 
+    if (mutableArgs.isEmpty()) {
+        manager.debugLog("No more arguments to complete. Waiting on user for input.")
+        return emptyList()
+    }
+
     // Prune passed parameters or complete current one
     val parameters = (completionNode as SubcommandNode).parameters
     for (parameter in parameters) {
@@ -61,18 +66,13 @@ fun tabComplete(manager: CommandManager<*>, sender: ICommandSender<*>, node: Com
                 manager.debugLog("Arguments: $mutableArgs")
 
                 // If there are no more args left, then return an empty list.
-                if (mutableArgs.isEmpty() || mutableArgs.first().isEmpty()) {
+                if (mutableArgs.isEmpty()) {
                     manager.debugLog("Parsed all args that we could, waiting on user for input.")
                     return emptyList()
                 }
 
                 continue
             }
-        }
-
-        if (input.isEmpty()) {
-            manager.debugLog("Waiting on user for input.")
-            return emptyList()
         }
 
         // This is the argument we need to complete.

--- a/common/src/main/kotlin/me/honkling/commando/common/TabCompleter.kt
+++ b/common/src/main/kotlin/me/honkling/commando/common/TabCompleter.kt
@@ -102,7 +102,7 @@ private fun getNode(node: CommandNode<*>, args: List<String>, count: Int = 0): P
     if (args.isEmpty() || args.first().isEmpty())
         return node to count
 
-    val childNode = node.children.find { it.name == args[0] || it.name == node.name } ?: return node to count
+    val childNode = node.children.find { it.name == args[0] } ?: return node to count
 
     if (childNode is CommandNode<*>)
         return getNode(childNode, args.slice(1..<args.size), count + 1)

--- a/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
+++ b/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
@@ -83,7 +83,11 @@ class MinestomCommandManager(plugin: MinestomPlugin, debugMode: Boolean = false)
                 }, params)
 
                 params.setSuggestionCallback { sender, context, suggestion ->
-                    val completions = tabComplete(this@MinestomCommandManager, SenderProvider(sender), node, context.get(params))
+                    // Replacement of \u0000 is a workaround for a bug in Brigadier (I think?) that appends a
+                    // null character to the end of the string, breaking any .startsWith() checks
+                    val completions = tabComplete(this@MinestomCommandManager, SenderProvider(sender), node,
+                        context.get(params).map { it.replace("\u0000", "") }.toTypedArray())
+
                     completions.forEach {
                         suggestion.addEntry(SuggestionEntry(it))
                     }

--- a/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
+++ b/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
@@ -13,6 +13,7 @@ import net.minestom.server.command.builder.Command
 import net.minestom.server.command.builder.CommandExecutor
 import net.minestom.server.command.builder.arguments.ArgumentType
 import net.minestom.server.command.builder.condition.CommandCondition
+import net.minestom.server.command.builder.suggestion.SuggestionEntry
 import net.minestom.server.entity.Player
 import net.minestom.server.permission.Permission
 import java.lang.reflect.Modifier
@@ -82,7 +83,10 @@ class MinestomCommandManager(plugin: MinestomPlugin, debugMode: Boolean = false)
                 }, params)
 
                 params.setSuggestionCallback { sender, context, suggestion ->
-                    tabComplete(this@MinestomCommandManager, SenderProvider(sender), node, context.get(params))
+                    val completions = tabComplete(this@MinestomCommandManager, SenderProvider(sender), node, context.get(params))
+                    completions.forEach {
+                        suggestion.addEntry(SuggestionEntry(it))
+                    }
                 }
             }
 

--- a/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
+++ b/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
@@ -52,7 +52,12 @@ class MinestomCommandManager(plugin: MinestomPlugin, debugMode: Boolean = false)
 
         val (subcommand, parameters) = result
         subcommand.method.isAccessible = true
-        
+
+        // Validate we're the correct sender
+        val senderType = subcommand.method.parameterTypes[0]
+        if (!senderType.isAssignableFrom(sender::class.java))
+            return false
+
         subcommand.method.invoke(null, sender, *parameters.toTypedArray())
 
         return true

--- a/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
+++ b/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
@@ -15,6 +15,7 @@ import net.minestom.server.command.builder.arguments.ArgumentType
 import net.minestom.server.command.builder.condition.CommandCondition
 import net.minestom.server.entity.Player
 import net.minestom.server.permission.Permission
+import java.lang.reflect.Modifier
 
 class MinestomCommandManager(plugin: MinestomPlugin, debugMode: Boolean = false) : CommandManager<MinestomPlugin>(Plugin(plugin), debugMode) {
     init {
@@ -50,6 +51,8 @@ class MinestomCommandManager(plugin: MinestomPlugin, debugMode: Boolean = false)
         }
 
         val (subcommand, parameters) = result
+        subcommand.method.isAccessible = true
+        
         subcommand.method.invoke(null, sender, *parameters.toTypedArray())
 
         return true

--- a/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
+++ b/minestom/src/main/kotlin/me/honkling/commando/minestom/MinestomCommandManager.kt
@@ -58,7 +58,11 @@ class MinestomCommandManager(plugin: MinestomPlugin, debugMode: Boolean = false)
         if (!senderType.isAssignableFrom(sender::class.java))
             return false
 
-        subcommand.method.invoke(null, sender, *parameters.toTypedArray())
+        val instance =
+            if (Modifier.isStatic(subcommand.method.modifiers)) null
+            else subcommand.method.declaringClass.getDeclaredField("INSTANCE")[null]
+
+        subcommand.method.invoke(instance, sender, *parameters.toTypedArray())
 
         return true
     }


### PR DESCRIPTION
Fixes bug in Common that blocks suggestions until the player starts typing
Fixes bug with Minestom that breaks any `.startsWith(args)` check when input is blank (removes random `\u0000` character)